### PR TITLE
Fixes for issues with multichar newline 

### DIFF
--- a/src/CsvHelper/CsvHelper.csproj
+++ b/src/CsvHelper/CsvHelper.csproj
@@ -8,7 +8,7 @@
 
 		<!-- Build -->
 		<AssemblyName>CsvHelper</AssemblyName>
-		<TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net47;net462</TargetFrameworks>
+		<TargetFrameworks>net6.0</TargetFrameworks>
 		<!--<TargetFrameworks>net60</TargetFrameworks>-->
 		<LangVersion>latest</LangVersion>
 		<RootNamespace>CsvHelper</RootNamespace>
@@ -17,7 +17,7 @@
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
         <!--<Nullable>enable</Nullable>
         <WarningsAsErrors>nullable</WarningsAsErrors>-->
-
+		<Version>73.2.0</Version>
 		<!-- Sign -->
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>CsvHelper.snk</AssemblyOriginatorKeyFile>

--- a/src/CsvHelper/CsvHelper.csproj
+++ b/src/CsvHelper/CsvHelper.csproj
@@ -8,7 +8,7 @@
 
 		<!-- Build -->
 		<AssemblyName>CsvHelper</AssemblyName>
-		<TargetFrameworks>net6.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net47;net462</TargetFrameworks>
 		<!--<TargetFrameworks>net60</TargetFrameworks>-->
 		<LangVersion>latest</LangVersion>
 		<RootNamespace>CsvHelper</RootNamespace>
@@ -17,7 +17,7 @@
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
         <!--<Nullable>enable</Nullable>
         <WarningsAsErrors>nullable</WarningsAsErrors>-->
-		<Version>73.2.0</Version>
+
 		<!-- Sign -->
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>CsvHelper.snk</AssemblyOriginatorKeyFile>

--- a/src/CsvHelper/CsvParser.cs
+++ b/src/CsvHelper/CsvParser.cs
@@ -358,7 +358,7 @@ namespace CsvHelper
 				}
 
 				var isFirstCharOfRow = rowStartPosition == bufferPosition - 1;
-				if (isFirstCharOfRow && (allowComments && c == comment || ignoreBlankLines && ((c == '\r' || c == '\n') && !isNewLineSet || isNewLineSet & c == newLineFirstChar && PeekAndCheck(c) == ParserState.NewLine)))
+				if (isFirstCharOfRow && (allowComments && c == comment || ignoreBlankLines && ((c == '\r' || c == '\n') && !isNewLineSet || isNewLineSet && c == newLineFirstChar && PeekAndCheck(c) == ParserState.NewLine)))
 				{
 					state = ParserState.BlankLine;
 					var result = ReadBlankLine(ref c);
@@ -569,7 +569,7 @@ namespace CsvHelper
 				}
 
 				var isFirstCharOfRow = rowStartPosition == bufferPosition - 1;
-				if (isFirstCharOfRow && (allowComments && c == comment || ignoreBlankLines && ((c == '\r' || c == '\n') && !isNewLineSet || isNewLineSet & c == newLineFirstChar && await PeekAndCheckAsync(c) == ParserState.NewLine)))
+				if (isFirstCharOfRow && (allowComments && c == comment || ignoreBlankLines && ((c == '\r' || c == '\n') && !isNewLineSet || isNewLineSet && c == newLineFirstChar && await PeekAndCheckAsync(c) == ParserState.NewLine)))
 				{
 					state = ParserState.BlankLine;
 					var result = ReadBlankLine(ref c);

--- a/src/CsvHelper/CsvParser.cs
+++ b/src/CsvHelper/CsvParser.cs
@@ -226,8 +226,6 @@ namespace CsvHelper
 			quoteCount = 0;
 			row++;
 			rawRow++;
-			var c = '\0';
-			var cPrev = c;
 
 			while (true)
 			{
@@ -244,7 +242,7 @@ namespace CsvHelper
 					}
 				}
 
-				if (ReadLine(ref c, ref cPrev) == ReadLineResult.Complete)
+				if (ReadLine() == ReadLineResult.Complete)
 				{
 					return true;
 				}
@@ -261,9 +259,7 @@ namespace CsvHelper
 			quoteCount = 0;
 			row++;
 			rawRow++;
-			var c = '\0';
-			var cPrev = c;
-
+			
 			while (true)
 			{
 				if (bufferPosition >= charsRead)
@@ -279,7 +275,7 @@ namespace CsvHelper
 					}
 				}
 
-				if (ReadLine(ref c, ref cPrev) == ReadLineResult.Complete)
+				if (await ReadLineAsync() == ReadLineResult.Complete)
 				{
 					return true;
 				}
@@ -298,8 +294,9 @@ namespace CsvHelper
 			}
 		}
 
-		private ReadLineResult ReadLine(ref char c, ref char cPrev)
+		private ReadLineResult ReadLine()
 		{
+			var c = buffer[Math.Max(0,bufferPosition - 1)];
 			while (bufferPosition < charsRead)
 			{
 				if (state != ParserState.None)
@@ -345,7 +342,7 @@ namespace CsvHelper
 					}
 				}
 
-				cPrev = c;
+				var cPrev = c;
 				c = buffer[bufferPosition];
 				bufferPosition++;
 				charCount++;
@@ -508,8 +505,9 @@ namespace CsvHelper
 			return ReadLineResult.Incomplete;
 		}
 		
-		private async Task<ReadLineResult> ReadLineAsync(char c, char cPrev)
+		private async Task<ReadLineResult> ReadLineAsync()
 		{
+			var c = buffer[Math.Max(0,bufferPosition - 1)];
 			while (bufferPosition < charsRead)
 			{
 				if (state != ParserState.None)
@@ -555,7 +553,7 @@ namespace CsvHelper
 					}
 				}
 
-				cPrev = c;
+				var cPrev = c;
 				c = buffer[bufferPosition];
 				bufferPosition++;
 				charCount++;

--- a/src/CsvHelper/CsvParser.cs
+++ b/src/CsvHelper/CsvParser.cs
@@ -1223,19 +1223,9 @@ namespace CsvHelper
 				return ParserState.None;
 			}
 
-			// think about it yo
-			if (c == newLineFirstChar && newLine.Length == 1)
-			{
-				return ParserState.NewLine;
-			}
-
-			if (c == delimiterFirstChar && delimiter.Length == 1)
-			{
-				return ParserState.Delimiter;
-			}
-			
 			var canBeNewLine = c == newLineFirstChar;
 			var canBeDelimiter = c == delimiterFirstChar;
+			
 			if (bufferPosition + peekLength > bufferSize)
 			{
 				FillBufferForPeek();
@@ -1257,17 +1247,6 @@ namespace CsvHelper
 				if (!canBeDelimiter && !canBeNewLine)
 				{
 					return ParserState.None;
-				}
-
-				// can exit early once we have read enough to confirm if it is 
-				if (!canBeNewLine && i >= delimiter.Length)
-				{
-					return ParserState.Delimiter;
-				}
-				
-				if (!canBeDelimiter && i >= newLine.Length)
-				{
-					return ParserState.NewLine;
 				}
 			}
 			

--- a/src/CsvHelper/CsvParser.cs
+++ b/src/CsvHelper/CsvParser.cs
@@ -569,7 +569,7 @@ namespace CsvHelper
 				}
 
 				var isFirstCharOfRow = rowStartPosition == bufferPosition - 1;
-				if (isFirstCharOfRow && (allowComments && c == comment || ignoreBlankLines && ((c == '\r' || c == '\n') && !isNewLineSet || isNewLineSet & c == newLineFirstChar && PeekAndCheck(c) == ParserState.NewLine)))
+				if (isFirstCharOfRow && (allowComments && c == comment || ignoreBlankLines && ((c == '\r' || c == '\n') && !isNewLineSet || isNewLineSet & c == newLineFirstChar && await PeekAndCheckAsync(c) == ParserState.NewLine)))
 				{
 					state = ParserState.BlankLine;
 					var result = ReadBlankLine(ref c);

--- a/tests/CsvHelper.Tests/CsvParserDelimiterTests.cs
+++ b/tests/CsvHelper.Tests/CsvParserDelimiterTests.cs
@@ -360,6 +360,8 @@ namespace CsvHelper.Tests
 			using (var parser = new CsvParser(reader, config))
 			{
 				writer.WriteLine("12340000004321|~|2|*|");
+				writer.WriteLine("2|~|12340000004321124|*|");
+				writer.WriteLine("2|~|12340000004321124|~|12340000004321124|*|");
 				writer.Flush();
 				stream.Position = 0;
 
@@ -368,9 +370,51 @@ namespace CsvHelper.Tests
 				Assert.Equal(2, parser.Count);
 				Assert.Equal("12340000004321", parser[0]);
 				Assert.Equal("2", parser[1]);
-
+				hasRecords = parser.Read();
+				
+				Assert.True(hasRecords);
+				Assert.Equal(2, parser.Count);
+				Assert.Equal("2", parser[0]);
+				Assert.Equal("12340000004321124", parser[1]);
+				hasRecords = parser.Read();
+				
+				
+				Assert.True(hasRecords);
+				Assert.Equal(3, parser.Count);
+				Assert.Equal("2", parser[0]);
+				Assert.Equal("12340000004321124", parser[1]);
+				Assert.Equal("12340000004321124", parser[2]);
 				hasRecords = parser.Read();
 				Assert.False(hasRecords);
+			}
+		}
+		
+		[Fact]
+		public void HandleFirstNewLineCharacterUnquoted()
+		{
+			var config = new CsvHelper.Configuration.CsvConfiguration(CultureInfo.InvariantCulture)
+			{
+				Delimiter = ",",
+				BufferSize = 14,
+				NewLine = "|*|"
+			};
+
+			using (var stream = new MemoryStream())
+			using (var reader = new StreamReader(stream))
+			using (var writer = new StreamWriter(stream))
+			using (var parser = new CsvParser(reader, config))
+			{
+				writer.WriteLine("12345|,2|*|\r\n");
+				writer.Flush();
+				stream.Position = 0;
+
+				var hasRecords = parser.Read();
+				Assert.True(hasRecords);
+				Assert.Equal(2, parser.Count);
+				Assert.Equal("12345|", parser[0]);
+				Assert.Equal("2", parser[1]);
+				hasRecords = parser.Read();
+
 			}
 		}
 	}

--- a/tests/CsvHelper.Tests/CsvParserDelimiterTests.cs
+++ b/tests/CsvHelper.Tests/CsvParserDelimiterTests.cs
@@ -318,7 +318,7 @@ namespace CsvHelper.Tests
 			var config = new CsvHelper.Configuration.CsvConfiguration(CultureInfo.InvariantCulture)
 			{
 				Delimiter = "|~|",
-				BufferSize = 16,
+				BufferSize = 16
 			};
 
 			using (var stream = new MemoryStream())
@@ -327,6 +327,39 @@ namespace CsvHelper.Tests
 			using (var parser = new CsvParser(reader, config))
 			{
 				writer.WriteLine("12340000004321|~|2");
+				writer.Flush();
+				stream.Position = 0;
+
+				var hasRecords = parser.Read();
+				Assert.True(hasRecords);
+				Assert.Equal(2, parser.Count);
+				Assert.Equal("12340000004321", parser[0]);
+				Assert.Equal("2", parser[1]);
+
+				hasRecords = parser.Read();
+				Assert.False(hasRecords);
+			}
+		}
+		
+		
+		
+		
+		[Fact]
+		public void MultipleCharDelimiterConflictingNewLineWithBufferEndingInMiddleOfDelimiterTest()
+		{
+			var config = new CsvHelper.Configuration.CsvConfiguration(CultureInfo.InvariantCulture)
+			{
+				Delimiter = "|~|",
+				BufferSize = 16,
+				NewLine = "|*|\r\n"
+			};
+
+			using (var stream = new MemoryStream())
+			using (var reader = new StreamReader(stream))
+			using (var writer = new StreamWriter(stream))
+			using (var parser = new CsvParser(reader, config))
+			{
+				writer.WriteLine("12340000004321|~|2|*|");
 				writer.Flush();
 				stream.Position = 0;
 

--- a/tests/CsvHelper.Tests/CsvParserRawRecordTests.cs
+++ b/tests/CsvHelper.Tests/CsvParserRawRecordTests.cs
@@ -139,5 +139,75 @@ namespace CsvHelper.Tests
 				Assert.Equal(string.Empty, parser.RawRecord.ToString());
 			}
 		}
+
+		[Fact]
+		public void HandleMultipleCharacter()
+		{
+			var config = new CsvConfiguration(CultureInfo.InvariantCulture)
+			{
+				NewLine = "|##|\r\n",
+				Delimiter = "|*|"
+			};
+			
+			using (var stream = new MemoryStream())
+			using (var writer = new StreamWriter(stream))
+			using (var reader = new StreamReader(stream))
+				
+			using (var parser = new CsvParser(reader, config))
+			{
+				writer.Write("1|*|2|##|\r\n");
+				writer.Write("3|*|4|##|\r\n");
+				writer.Write("|*5|*|6|##|\r\n");
+				writer.Write("7|##||*|6||##|\r\n");
+				writer.Flush();
+				stream.Position = 0;
+
+				parser.Read();
+				Assert.Equal("1|*|2|##|\r\n", parser.RawRecord);
+
+				parser.Read();
+				Assert.Equal("3|*|4|##|\r\n", parser.RawRecord);
+
+				parser.Read();
+				Assert.Equal("|*5|*|6|##|\r\n", parser.RawRecord);
+				
+				parser.Read();
+				Assert.Equal("7|##||*|6||##|\r\n", parser.RawRecord);
+				
+				parser.Read();
+				Assert.Equal(string.Empty, parser.RawRecord.ToString());
+			}
+		}
+		
+		[Fact]
+		public void HandleMultipleCharacterSmallBuffer()
+		{
+			var config = new CsvConfiguration(CultureInfo.InvariantCulture)
+			{
+				NewLine = "|##|\r\n",
+				Delimiter = "|*|",
+				BufferSize = 1,
+			};
+			
+			using (var stream = new MemoryStream())
+			using (var writer = new StreamWriter(stream))
+			using (var reader = new StreamReader(stream))
+			using (var parser = new CsvParser(reader, config))
+			{
+				writer.Write("1|*|2|##|\r\n");
+				writer.Write("3|*|4|##|\r\n");
+				writer.Flush();
+				stream.Position = 0;
+
+				parser.Read();
+				Assert.Equal("1|*|2|##|\r\n", parser.RawRecord.ToString());
+
+				parser.Read();
+				Assert.Equal("3|*|4|##|\r\n", parser.RawRecord.ToString());
+
+				parser.Read();
+				Assert.Equal(string.Empty, parser.RawRecord.ToString());
+			}
+		}
 	}
 }

--- a/tests/CsvHelper.Tests/CsvParserTests.cs
+++ b/tests/CsvHelper.Tests/CsvParserTests.cs
@@ -1396,5 +1396,93 @@ namespace CsvHelper.Tests
 				Assert.Equal(1, parser.RawRow);
 			}
 		}
+		
+		[Fact]
+		public void LongNewLineCharacterWithNoLineEndingOnLastLineTest()
+		{
+			var config = new CsvConfiguration(CultureInfo.InvariantCulture)
+			{
+				AllowComments = true,
+				NewLine = "|1234567|\r\n"
+			};
+			using (var stream = new MemoryStream())
+			using (var reader = new StreamReader(stream))
+			using (var writer = new StreamWriter(stream))
+			using (var parser = new CsvParser(reader, config))
+			{
+				writer.Write("1,2|1234567|\r\n");
+				writer.Write("3,4");
+				writer.Flush();
+				stream.Position = 0;
+
+				parser.Read();
+				Assert.Equal(2,parser.Count);
+				Assert.Equal("2",parser[1]);
+				parser.Read();
+				Assert.Equal(2,parser.Count);
+				Assert.Equal("4",parser[1]);
+				Assert.False(parser.Read());
+			}
+		}
+		
+		[Fact]
+		public void LongNewLineCharacterWithNoLineEndingOnLastLineTestWithSmallBuffer()
+		{
+			var config = new CsvConfiguration(CultureInfo.InvariantCulture)
+			{
+				AllowComments = true,
+				NewLine = "|1234567|\r\n",
+				BufferSize = 17
+			};
+			using (var stream = new MemoryStream())
+			using (var reader = new StreamReader(stream))
+			using (var writer = new StreamWriter(stream))
+			using (var parser = new CsvParser(reader, config))
+			{
+				writer.Write("1,2|1234567|\r\n");
+				writer.Write("3,4");
+				writer.Flush();
+				stream.Position = 0;
+
+				parser.Read();
+				Assert.Equal(2,parser.Count);
+				Assert.Equal("2",parser[1]);
+				parser.Read();
+				Assert.Equal(2,parser.Count);
+				Assert.Equal("4",parser[1]);
+				Assert.False(parser.Read());
+			}
+		}
+		
+		
+		[Fact]
+		public void LongNewLineCharacterWithNoLineEndingOnLastLineTestWithSameBufferSizeAsLength()
+		{
+			var config = new CsvConfiguration(CultureInfo.InvariantCulture)
+			{
+				AllowComments = true,
+				NewLine = "|1234567|\r\n",
+				BufferSize = 17
+			};
+			using (var stream = new MemoryStream())
+			using (var reader = new StreamReader(stream))
+			using (var writer = new StreamWriter(stream))
+			using (var parser = new CsvParser(reader, config))
+			{
+				writer.Write("1,2|1234567|\r\n");
+				writer.Write("3,4");
+				writer.Flush();
+				stream.Position = 0;
+
+				parser.Read();
+				Assert.Equal(2,parser.Count);
+				Assert.Equal("2",parser[1]);
+				parser.Read();
+				Assert.Equal(2,parser.Count);
+				Assert.Equal("4",parser[1]);
+				Assert.False(parser.Read());
+			}
+		}
+		
 	}
 }

--- a/tests/CsvHelper.Tests/CsvParserTests.cs
+++ b/tests/CsvHelper.Tests/CsvParserTests.cs
@@ -819,7 +819,7 @@ namespace CsvHelper.Tests
 			using (var reader = new StreamReader(stream))
 			using (var parser = new CsvParser(reader, config))
 			{
-				writer.Write("|1,a|##|\r\n");
+				writer.Write("|##|,a|##|\r\n");
 				writer.Write("|##|\r\n");
 				writer.WriteLine("3|,c|##|\r\n");
 				writer.Flush();
@@ -827,7 +827,7 @@ namespace CsvHelper.Tests
 
 				Assert.True(parser.Read());
 				Assert.Equal(1, parser.Row);
-				Assert.Equal("|1", parser[0]);
+				Assert.Equal("|##|", parser[0]);
 
 				Assert.True(parser.Read());
 				Assert.Equal(3, parser.Row);

--- a/tests/CsvHelper.Tests/CsvParserTests.cs
+++ b/tests/CsvHelper.Tests/CsvParserTests.cs
@@ -804,6 +804,36 @@ namespace CsvHelper.Tests
 				Assert.Equal("3", parser[0]);
 			}
 		}
+		
+		
+		[Fact]
+		public void IgnoreBlankLinesRowCountTestWithMultipleCharacterNewLine()
+		{
+			var config = new CsvHelper.Configuration.CsvConfiguration(CultureInfo.InvariantCulture)
+			{
+				IgnoreBlankLines = true,
+				NewLine = "|##|\r\n"
+			};
+			using (var stream = new MemoryStream())
+			using (var writer = new StreamWriter(stream))
+			using (var reader = new StreamReader(stream))
+			using (var parser = new CsvParser(reader, config))
+			{
+				writer.Write("|1,a|##|\r\n");
+				writer.Write("|##|\r\n");
+				writer.WriteLine("3|,c|##|\r\n");
+				writer.Flush();
+				stream.Position = 0;
+
+				Assert.True(parser.Read());
+				Assert.Equal(1, parser.Row);
+				Assert.Equal("|1", parser[0]);
+
+				Assert.True(parser.Read());
+				Assert.Equal(3, parser.Row);
+				Assert.Equal("3|", parser[0]);
+			}
+		}
 
 		[Fact]
 		public void DoNotIgnoreBlankLinesRowCountTest()

--- a/tests/CsvHelper.Tests/Parsing/BufferSplittingNewLineEndingTests.cs
+++ b/tests/CsvHelper.Tests/Parsing/BufferSplittingNewLineEndingTests.cs
@@ -98,5 +98,28 @@ namespace CsvHelper.Tests.Parsing
 				Assert.Equal("5,\"600\"\r\n", parser.RawRecord);
 			}
 		}
+		
+		[Fact]
+		public void BufferSplitsLongNewLineTest()
+		{
+			var s = new StringBuilder();
+			s.Append("1,200000|123456789012345678901234567890|\r\n");
+			s.Append("3,4000|123456789012345678901234567890|\r\n");
+			var config = new CsvHelper.Configuration.CsvConfiguration(CultureInfo.InvariantCulture)
+			{
+				BufferSize = 16,
+				NewLine = "|123456789012345678901234567890|\r\n",
+			};
+			using (var reader = new StringReader(s.ToString()))
+			using (var parser = new CsvParser(reader, config))
+			{
+				parser.Read();
+				Assert.Equal(2, parser.Count);
+				Assert.Equal("1,200000|123456789012345678901234567890|\r\n", parser.RawRecord);
+				parser.Read();
+				Assert.Equal(2, parser.Count);
+				Assert.Equal("3,4000|123456789012345678901234567890|\r\n", parser.RawRecord);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Fixes for the issues mentioned [here](https://github.com/JoshClose/CsvHelper/issues/2216)

TLDR: Added a new method that looks ahead in the buffer to ensure the character we are at is the start of a newline/delimiter character. Added in a secondary method to facilitate filling the buffer in the case there is not enough room to fully peek. All this peek functionality is only used in the case that the delimiter or newline is more than 1 character long (and not CRLF). 

As part of these changes I have also had to introduce a private ReadLineAsync function as there is an async overload for the peek buffer functionality. This does mean I have had to remove the ref parameters from both functions, it was only really being used to compare between previous and current reads and that information could be gathered from within the function through the buffer.

Will merge and squash into our repo so we can build the artifact and then make the PR into their repo.